### PR TITLE
DateTimeZone caching issue

### DIFF
--- a/includes/event-organiser-event-functions.php
+++ b/includes/event-organiser-event-functions.php
@@ -719,7 +719,7 @@ function eo_get_blog_timezone(){
 
 		$timezone = new DateTimeZone($tzstring);
 
-		if ( $timezone->getOffset() !== false )
+		if ( version_compare( PHP_VERSION, '5.2.0', '<=' ) )
 			wp_cache_set( 'eventorganiser_timezone', $timezone );
 	} 
 


### PR DESCRIPTION
This provides a quick fix for the Object Caching issue experienced with W3 Total Cache creating a server error 500.

Track the issue down to setting/getting the cached in event-organiser-event-functions.php

wp_cache_set( 'eventorganiser_timezone', $timezone );

After a bit of digging I found that DateTimeZone must be configured in the PHP ini file in PHP 5.3.0+ (which a lot of on-the-ball hosts are now offering)
http://www.silverstripe.org/installing-silverstripe/show/15398

So I'm not sure why the cached version of this object causes a problem when it works find if you comment out the line that saves the object cache (above).

As a temporary fix, this patch only caches the DateTimeZone object if it returns a value for getOffset()
