### PR TITLE
add hook so plugins are informed of occurrence deletion

### DIFF
--- a/event-organiser-calendar.php
+++ b/event-organiser-calendar.php
@@ -191,7 +191,7 @@ class EventOrganiser_Calendar_Page extends EventOrganiser_Admin_Page
 					$EO_Errors = new WP_Error( 'eo_notice', '<strong>'.__( 'Occurrence deleted.', 'eventorganiser' ).'</strong>' );
 					
 					//Allow plugins to be aware of successful deletions
-					do_action( 'eventorganiser_removed_occurrence', $post_id, $event_id );
+					do_action( 'eventorganiser_admin_calendar_occurence_deleted', $post_id, $event_id );
 
 				}
 			endif;


### PR DESCRIPTION
Hi Stephen, 

I'm writing a plugin that tracks EO events and the actions taken to modify them. The hook I've added allows my plugin to be aware of when people click "Delete this occurrence" in the Calendar view. Would be great if you'd include this, since all other modifications except for this one can be tracked via other hooks.

Great plugin, BTW, many thanks for your efforts.

TIA, Christian
