### PR TITLE
Fix php strict error for a function which is always called statically.

### DIFF
--- a/classes/class-eventorganiser-shortcodes.php
+++ b/classes/class-eventorganiser-shortcodes.php
@@ -379,7 +379,7 @@ class EventOrganiser_Shortcodes {
 		return $replacement;
 	}
 
-	function eo_clean_input($input){
+	static function eo_clean_input($input){
 		$input = trim($input,"{}"); //remove { }
 		$input = str_replace(array("'",'"',"&#8221;","&#8216;", "&#8217;"),'',$input); //remove quotations
 		return $input;


### PR DESCRIPTION
Ran into an issue during local development:

```
Strict standards: Non-static method EventOrganiser_Shortcodes::eo_clean_input() should not be called statically in wp-content/plugins/event-organiser/classes/class-eventorganiser-shortcodes.php on line 255
```

Given the fact that this function is only called statically, let's also declare it statically.
