### PR TITLE
Update event-organiser-register.php to call jquery-ui-button in admin

### DIFF
--- a/includes/event-organiser-register.php
+++ b/includes/event-organiser-register.php
@@ -106,6 +106,7 @@ function eventorganiser_register_scripts(){
 		'eo-time-picker',
 		'jquery-ui-autocomplete',
 		'jquery-ui-widget',
+		'jquery-ui-button',
 		'jquery-ui-position'
 	),$version,true);
 	
@@ -120,6 +121,7 @@ function eventorganiser_register_scripts(){
 		'jquery-ui-datepicker',
 		'jquery-ui-autocomplete',
 		'jquery-ui-widget',
+		'jquery-ui-button',
 		'jquery-ui-dialog',
 		'jquery-ui-tabs',
 		'jquery-ui-position'


### PR DESCRIPTION
Fix for jquery-ui-button not being called in admin

TypeError: $(...).attr(...).appendTo(...).button is not a function
wp-content/plugins/event-organiser/js/edit-event-controller.js?ver=2.7.4 Line 139
