### PR TITLE
iCalendar feed validation

### DIFF
--- a/templates/ical.php
+++ b/templates/ical.php
@@ -1,139 +1,138 @@
-BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//<?php  get_bloginfo('name'); ?>//NONSGML Events //EN
-CALSCALE:GREGORIAN
-X-WR-CALNAME:<?php echo get_bloginfo('name');?> - Events
-X-ORIGINAL-URL:<?php echo get_post_type_archive_link('event') . "\n"; ?>
-X-WR-CALDESC:<?php echo get_bloginfo('name');?> - Events
 <?php
-	// Loop through events
-	if ( have_posts() ):
-		$now = new DateTime();
-		$dtstamp =$now->format('Ymd\THis\Z');
-		$UTC_tz = new DateTimeZone('UTC');
 
-		while( have_posts() ): the_post();
-			global $post;
+echo "BEGIN:VCALENDAR\r\n";
+echo "VERSION:2.0\r\n";
+echo "PRODID:-//" . get_bloginfo('name') . "//NONSGML Events//EN\r\n";
+echo "CALSCALE:GREGORIAN\r\n";
+echo "X-WR-CALNAME:" . get_bloginfo('name') . " - Events\r\n";
+echo "X-ORIGINAL-URL:" . get_post_type_archive_link('event') . "\r\n";
+echo "X-WR-CALDESC:" . get_bloginfo('name') . " - Events\r\n";
 
-			//If event has no corresponding row in events table then skip it
-			if(!isset($post->event_id) || $post->event_id==-1)
-				continue;
+// Loop through events
+if ( have_posts() ) :
 
-			$start = eo_get_the_start(DATETIMEOBJ);
-			$end = eo_get_the_end(DATETIMEOBJ);
-			$created_date = get_post_time('Ymd\THis\Z',true);
-			$modified_date = get_post_modified_time('Ymd\THis\Z',true);
-			$schedule_data = eo_get_event_schedule();
+	$now = new DateTime();
+	$dtstamp = $now->format('Ymd\THis\Z');
+	$UTC_tz = new DateTimeZone('UTC');
 
-			//Set up start and end date times
-			if( eo_is_all_day() ){
-				$format =	'Ymd';
-				$start_date = $start->format($format);
-				$end->modify('+1 minute');
-				$end_date = $end->format($format);				
-			}else{
-				$format =	'Ymd\THis\Z';
-				$start->setTimezone($UTC_tz);
-				$start_date =$start->format($format);
-				$end->setTimezone($UTC_tz);
-				$end_date = $end->format($format);
-			}
+	while( have_posts() ): the_post();
+	
+		global $post;
 
-			//Generate Event status
-			if( get_post_status(get_the_ID()) == 'publish' )
-				$status = 'CONFIRMED';
-			else
-				$status = 'TENTATIVE';
+		// If event has no corresponding row in events table then skip it
+		if ( !isset($post->event_id) || $post->event_id == -1 )
+			continue;
 
-			//Output event
-?>
-BEGIN:VEVENT
-UID:<?php echo eo_get_event_uid();?>
+		$start = eo_get_the_start(DATETIMEOBJ);
+		$end = eo_get_the_end(DATETIMEOBJ);
+		$created_date = get_post_time('Ymd\THis\Z',true);
+		$modified_date = get_post_modified_time('Ymd\THis\Z',true);
+		$schedule_data = eo_get_event_schedule();
 
-STATUS:<?php echo $status;?>
-
-DTSTAMP:<?php echo $dtstamp;?>
-
-CREATED:<?php echo $created_date;?>
-
-LAST-MODIFIED:<?php echo $modified_date;?>
-
-<?php if( eo_is_all_day() ): ?>
-DTSTART;VALUE=DATE:<?php echo $start_date ; ?>
-
-DTEND;VALUE=DATE:<?php echo $end_date; ?>
-<?php else: ?>
-DTSTART:<?php echo $start_date ; ?>
-
-DTEND:<?php echo $end_date; ?>
-<?php endif;?>
-
-<?php if ( $reoccurrence_rule = eventorganiser_generate_ics_rrule() ):?>
-RRULE:<?php echo $reoccurrence_rule;?>
-
-<?php endif;?>
-<?php if( !empty($schedule_data['exclude']) ):
-	$exclude_strings = array();
-	foreach ( $schedule_data['exclude'] as $exclude ){
-		if( !eo_is_all_day() ){
-			$vdate='';
-			$exclude->setTimezone($UTC_tz);
-			$exclude_strings[] = $exclude->format('Ymd\THis\Z');
-		}else{
-			$vdate=';VALUE=DATE';
-			$exclude_strings[] = $exclude->format('Ymd');
+		// Set up start and end date times
+		if ( eo_is_all_day() ) {
+			$format =	'Ymd';
+			$start_date = $start->format($format);
+			$end->modify('+1 minute');
+			$end_date = $end->format($format);				
+		} else {
+			$format =	'Ymd\THis\Z';
+			$start->setTimezone($UTC_tz);
+			$start_date =$start->format($format);
+			$end->setTimezone($UTC_tz);
+			$end_date = $end->format($format);
 		}
-	}?>
-EXDATE<?php echo $vdate;?>:<?php echo implode(',',$exclude_strings);?>
 
-<?php endif;?>
-<?php if( !empty($schedule_data['include']) ):
-	$include_strings = array();
-		foreach ( $schedule_data['include'] as $include ){
-			if( !eo_is_all_day() ){
-				$vdate='';
-				$include->setTimezone($UTC_tz);
-				$include_strings[] = $include->format('Ymd\THis\Z');
-			}else{
-				$vdate=';VALUE=DATE';
-				$include_strings[] = $include->format('Ymd');
+		// Generate Event status
+		if ( get_post_status(get_the_ID()) == 'publish' )
+			$status = 'CONFIRMED';
+		else
+			$status = 'TENTATIVE';
+
+		// Output event
+		echo "BEGIN:VEVENT\r\n";
+		echo "UID:" . eo_get_event_uid() . "\r\n";
+		echo "STATUS:" . $status . "\r\n";
+		echo "DTSTAMP:" . $dtstamp . "\r\n";
+		echo "CREATED:" . $created_date . "\r\n";
+		echo "LAST-MODIFIED:" . $modified_date . "\r\n";
+		
+		if ( eo_is_all_day() ) :
+			echo "DTSTART;VALUE=DATE:" . $start_date . "\r\n";
+			echo "DTEND;VALUE=DATE:" . $end_date . "\r\n";
+		else :
+			echo "DTSTART:" . $start_date . "\r\n";
+			echo "DTEND:" . $end_date . "\r\n";
+		endif;
+		
+		if ( $reoccurrence_rule = eventorganiser_generate_ics_rrule() ) :
+			echo "RRULE:" . $reoccurrence_rule . "\r\n";
+		endif;
+		
+		if ( !empty($schedule_data['exclude']) ) :
+			$exclude_strings = array();
+			foreach ( $schedule_data['exclude'] as $exclude ){
+				if ( !eo_is_all_day() ){
+					$vdate = '';
+					$exclude->setTimezone($UTC_tz);
+					$exclude_strings[] = $exclude->format('Ymd\THis\Z');
+				}else{
+					$vdate = ';VALUE=DATE';
+					$exclude_strings[] = $exclude->format('Ymd');
+				}
 			}
-	}?>
-RDATE<?php echo $vdate;?>:<?php echo implode(',',$include_strings);?>
+			echo "EXDATE" . $vdate . ":" . implode(',',$exclude_strings) . "\r\n";
+		endif;
+		
+		if ( !empty($schedule_data['include']) ) :
+			$include_strings = array();
+			foreach ( $schedule_data['include'] as $include ){
+				if ( !eo_is_all_day() ){
+					$vdate = '';
+					$include->setTimezone($UTC_tz);
+					$include_strings[] = $include->format('Ymd\THis\Z');
+				}else{
+					$vdate = ';VALUE=DATE';
+					$include_strings[] = $include->format('Ymd');
+				}
+			}
+			echo "RDATE" . $vdate . ":" . implode(',',$include_strings) . "\r\n";
+		endif;
+		
+		echo eventorganiser_fold_ical_text( html_entity_decode( 
+			"SUMMARY: " . eventorganiser_escape_ical_text( get_the_title_rss() ) ) 
+		) . "\r\n";
+		
+		$excerpt = get_the_excerpt();
+		$excerpt = eventorganiser_escape_ical_text( apply_filters('the_excerpt_rss', $excerpt) );
+		if ( !empty($excerpt) ) :
+			echo eventorganiser_fold_ical_text( html_entity_decode( "DESCRIPTION: $excerpt" ) ) . "\r\n";
+		endif;
+		
+		$description = eventorganiser_escape_ical_text( get_the_content() );
+		echo eventorganiser_fold_ical_text( html_entity_decode( "X-ALT-DESC;FMTTYPE=text/html: $description" ) ) . "\r\n";
+		
+		$cats = get_the_terms( get_the_ID(), 'event-category' );
+		if ( $cats && !is_wp_error($cats) ) :
+			$cat_names = wp_list_pluck($cats, 'name');
+			$cat_names = array_map( 'eventorganiser_escape_ical_text', $cat_names );
+			echo "CATEGORIES:" . implode(',',$cat_names) . "\r\n";
+		endif;
+		
+		if ( eo_get_venue() ) :
+			$venue = eo_get_venue_name( eo_get_venue() );
+			echo "LOCATION:" . eventorganiser_fold_ical_text( eventorganiser_escape_ical_text( $venue ) ) . "\r\n";
+			echo "GEO:" . implode( ';', eo_get_venue_latlng( $venue ) ) . "\r\n";
+		endif;
+		
+		$author_name = eventorganiser_escape_ical_text( get_the_author() );
+		$author_email = eventorganiser_escape_ical_text( get_the_author_meta( 'user_email' ) );
+		echo eventorganiser_fold_ical_text( 'ORGANIZER;CN="' . $author_name . '":MAILTO:' . $author_email ) . "\r\n";
+		
+		echo "END:VEVENT\r\n";
 
-<?php endif; ?>
-<?php echo eventorganiser_fold_ical_text( html_entity_decode( "SUMMARY: " . eventorganiser_escape_ical_text( get_the_title_rss() ) ) ) . "\n" ;?>
-<?php
-	$excerpt = get_the_excerpt();
-	$excerpt = eventorganiser_escape_ical_text( apply_filters('the_excerpt_rss', $excerpt) );
-	if( !empty($excerpt) ):
-		echo eventorganiser_fold_ical_text( html_entity_decode( "DESCRIPTION: $excerpt" ) ) . "\n";
-	endif; ?>
-<?php 
-	$description = eventorganiser_escape_ical_text( get_the_content() );
-	echo eventorganiser_fold_ical_text( html_entity_decode( "X-ALT-DESC;FMTTYPE=text/html: $description" ) ) . "\n";
-?>
-<?php 
-	$cats = get_the_terms( get_the_ID(), 'event-category' );
-if( $cats && !is_wp_error($cats) ):
-	$cat_names = wp_list_pluck($cats, 'name');
-	$cat_names = array_map( 'eventorganiser_escape_ical_text', $cat_names ); ?>
-CATEGORIES:<?php echo implode(',',$cat_names); ?>
+	endwhile;
 
-<?php endif; ?>
-<?php
-if( eo_get_venue() ): 
-	$venue = eo_get_venue_name( eo_get_venue() );
-?>
-LOCATION:<?php echo eventorganiser_fold_ical_text( eventorganiser_escape_ical_text( $venue ) ) . "\n";?>
-GEO:<?php echo implode( ';', eo_get_venue_latlng( $venue ) ) . "\n";?>
-<?php endif; ?>
-ORGANIZER:<?php echo eventorganiser_fold_ical_text( eventorganiser_escape_ical_text( get_the_author() ) );?>
+endif;
 
-END:VEVENT
-<?php
-		endwhile;
-
-	endif;
-?>
-END:VCALENDAR
+echo "END:VCALENDAR\r\n";


### PR DESCRIPTION
As part of the debugging process that resulted in [the BP Docs conflict](https://github.com/boonebgorges/buddypress-docs/issues/425) I posted on that repo earlier, I initially thought that empty calendars I was seeing may have been to result of the iCalendar template output. I discovered that the iCal feed template does indeed produce output that does not validate, as perhaps suggested by [this comment](https://github.com/stephenharris/Event-Organiser/commit/665881b7e35c59ae45a6dfed17d568ec112827f8#commitcomment-3783835) on the initial commit.

IIRC, the issues with it were:
- Every line must end with `CRLF`
- The `ORGANIZER` token needs to be of the form `ORGANIZER;CN="John Smith":MAILTO:jsmith@host.com`
- "folded" lines had extra whitespace which caused anything after the break to be parsed as a token

Er, I think that was it... 
