### PR TITLE
Allow calendar transients to be overridden

### DIFF
--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -76,7 +76,7 @@ function eventorganiser_public_fullcalendar() {
 		$key = "eo_fc_".md5( serialize( $query ). $time_format );
 	}
 	
-	$calendar = get_transient( "eo_full_calendar_public{$priv}");
+	$calendar = get_transient( apply_filters( 'eo_full_calendar_transient_key', "eo_full_calendar_public{$priv}" ) );
 	if( $calendar && is_array( $calendar ) && isset( $calendar[$key] ) ){
 		$events_array = $calendar[$key];
 		/**
@@ -280,7 +280,7 @@ function eventorganiser_public_fullcalendar() {
 	
 	$calendar[$key] = $events_array;
 
-	set_transient( "eo_full_calendar_public{$priv}",$calendar, 60*60*24);
+	set_transient( apply_filters( 'eo_full_calendar_transient_key', "eo_full_calendar_public{$priv}" ), $calendar, 60*60*24);
 	
 	$events_array = apply_filters( 'eventorganiser_fullcalendar', $events_array, $query );
 
@@ -807,6 +807,7 @@ function eventorganiser_admin_calendar_edit_date(){
 			'data' => array(
 				'message' => __( 'Are you sure you want to do this?', 'eventorganiser' )
 			),
+
 		));
 		exit;
 	}

--- a/includes/event-organiser-register.php
+++ b/includes/event-organiser-register.php
@@ -547,8 +547,8 @@ foreach( $hooks as $hook ){
  */
 function _eventorganiser_delete_calendar_cache() {
 	delete_transient( 'eo_widget_calendar' );
-	delete_transient( 'eo_full_calendar_public' );
-	delete_transient( 'eo_full_calendar_public_priv' );
+	delete_transient( apply_filters( 'eo_full_calendar_transient_key', 'eo_full_calendar_public' ) );
+	delete_transient( apply_filters( 'eo_full_calendar_transient_key', 'eo_full_calendar_public_priv' ) );
 	delete_transient( 'eo_full_calendar_admin' );
 	delete_transient( 'eo_widget_agenda' );
 }


### PR DESCRIPTION
Hi @stephenharris - Wanted to let you know that development on the BuddyPress Event Organiser plugin has begun again (which allows events to be assigned to BP groups) and one of the issues that's been raised is the calendar caching, which - at present - needs to be busted every time a calendar is shown.

This PR adds a filter so that the the `eo_full_calendar_public` and `eo_full_calendar_public_priv` transients can be renamed on the fly. I think this is the minimum change required to implement caching that's a bit more flexible, but I'd be interested to hear your thoughts on a more adaptable caching mechanism. Is this a good way to go? Or might it be better to allow the entire transient-caching system to be bypassed?

BTW, the commit seems to include various whitespace-related changes, but they're because the 'includes/event-organiser-ajax.php' file contains a number of `\r\n` line-endings which were messing with my text editor. Sorry about that. It's only the lines containing `eo_full_calendar_transient_key` that are relevant.