### PR TITLE
Filters public fullCalendar for third-party cache busting.

### DIFF
--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -67,6 +67,19 @@ function eventorganiser_public_fullcalendar() {
 
 	//Retrieve events		
 	$query = array_merge( $request, $presets );
+
+	/**
+	 * Filters the query before it is sent to the calendar.
+	 *
+	 * The returned $query array is used to generate the cache key. The `$query`
+	 * array can contain any keys supported by `eo_get_events()`, and so also
+	 * `get_posts()` and `WP_Query()`.
+	 *
+	 * @package fullCalendar
+	 * @since 2.13.0
+	 * @param array  $query An query array (as given to `eo_get_events()`)
+	 */
+	$query = apply_filters( 'eventorganiser_fullcalendar_query', $query );
 	
 	//In case polylang is enabled with events as translatable. Include locale in cache key.
 	$options = get_option( 'polylang' );
@@ -75,8 +88,6 @@ function eventorganiser_public_fullcalendar() {
 	}else{
 		$key = 'eo_fc_'.md5( serialize( $query ). $time_format );
 	}
-	
-	$key = apply_filters( 'eventorganiser_fullcalendar_cache_key', $key, $query );
 	
 	$calendar = get_transient( "eo_full_calendar_public{$priv}" );
 	if( $calendar && is_array( $calendar ) && isset( $calendar[$key] ) ){

--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -66,17 +66,19 @@ function eventorganiser_public_fullcalendar() {
 	}
 
 	//Retrieve events		
-	$query    = array_merge( $request, $presets );
+	$query = array_merge( $request, $presets );
 	
 	//In case polylang is enabled with events as translatable. Include locale in cache key.
 	$options = get_option( 'polylang' );
 	if( defined( 'POLYLANG_VERSION' ) && !empty( $options['post_types']  ) && in_array( 'event', $options['post_types'] ) ){
-		$key = "eo_fc_".md5( serialize( $query ). $time_format . get_locale() );
+		$key = 'eo_fc_'.md5( serialize( $query ). $time_format . get_locale() );
 	}else{
-		$key = "eo_fc_".md5( serialize( $query ). $time_format );
+		$key = 'eo_fc_'.md5( serialize( $query ). $time_format );
 	}
 	
-	$calendar = get_transient( "eo_full_calendar_public{$priv}");
+	$key = apply_filters( 'eventorganiser_fullcalendar_cache_key', $key, $query );
+	
+	$calendar = get_transient( "eo_full_calendar_public{$priv}" );
 	if( $calendar && is_array( $calendar ) && isset( $calendar[$key] ) ){
 		$events_array = $calendar[$key];
 		/**


### PR DESCRIPTION
See issue #250 

Example:

```
add_filter( 'eventorganiser_fullcalendar_cache_key', 'my_cache_key_callback' );
function my_cache_key_callback( $key ){
       $foobar = $_REQUEST['foobar'];
       return md5( $key . $foobar );
}
```