### PR TITLE
Introduce 'eventorganiser_additional_event_meta' template hook.

### DIFF
--- a/templates/event-meta-event-single.php
+++ b/templates/event-meta-event-single.php
@@ -102,6 +102,8 @@
 				<?php endif; ?>
 		<?php } ?>
 
+		<?php do_action( 'eventorganiser_additional_event_meta' ) ?>
+
 	</ul>
 
 	<!-- Does the event have a venue? -->


### PR DESCRIPTION
I'd like to add additional data in the `event-meta-event-single.php` template without having to overload the entire thing. How's about a hook?