### PR TITLE
Introduce different hooks for event creation and editing.

### DIFF
--- a/includes/event.php
+++ b/includes/event.php
@@ -107,6 +107,14 @@ function eo_update_event( $post_id, $event_data = array(), $post_data = array() 
 	 * @param int $post_id The ID of the event
 	 */
 	do_action( 'eventorganiser_save_event', $post_id );
+
+	/**
+	 * Fires after an event has been updated.
+	 *
+	 * @param int $post_id The ID of the event.
+	 */
+	do_action( 'eventorganiser_updated_event', $post_id );
+
 	return $post_id;
 }
 
@@ -232,6 +240,14 @@ function eo_insert_event( $post_data = array(), $event_data = array() ){
 	 * @param int $post_id The ID of the event 
 	 */
 	do_action( 'eventorganiser_save_event', $post_id );
+
+	/**
+	 * Fires after an event has been created.
+	 *
+	 * @param int $post_id The ID of the event.
+	 */
+	do_action( 'eventorganiser_created_event', $post_id );
+
 	return $post_id;
 }
 


### PR DESCRIPTION
The 'eventorganiser_save_event' action fires both during `eo_insert_event()`
and during `eo_update_event()`, with no easy way to tell the difference.
Having separate actions will make it easy to distinguish between event creation
and editing.

Passing something like an `$is_new` param to 'eventorganiser_save_event' would accomplish much the same thing. I don't have a preference. I also chose what sounded to me like good action names, but you should feel free to use something else :)