### PR TITLE
Prevent PHP notices during unit tests

### DIFF
--- a/event-organiser.php
+++ b/event-organiser.php
@@ -47,8 +47,10 @@ function _eventorganiser_set_constants(){
  	* Defines the plug-in directory url
  	* <code>url:http://mysite.com/wp-content/plugins/event-organiser</code>
 	*/
-	define( 'EVENT_ORGANISER_URL', plugin_dir_url( __FILE__ ) );
-	
+	if ( ! defined( 'EVENT_ORGANISER_URL' ) ) {
+		define( 'EVENT_ORGANISER_URL', plugin_dir_url( __FILE__ ) );
+	}
+
 	require_once(EVENT_ORGANISER_DIR.'event-organiser-add-ons.php');
 	
 	if( !defined( 'EVENT_ORGANISER_BETA_FEATURES' ) ){


### PR DESCRIPTION
The way that we're bootstrapping and installing `event-organiser` during unit tests - see https://github.com/cuny-academic-commons/bp-event-organiser/blob/master/tests/phpunit/bootstrap.php#L13 for more details - means that EO is loaded a bit earlier than it normally is (basically, as an mu-plugin). This causes a couple of notices to be thrown. The two attached changesets prevent these notices in what is, I think, a harmless way. Very low priority :)