### PR TITLE
Don't use `$compat` global variable when setting up theme compatibility.

### DIFF
--- a/includes/class-eo-theme-compatability.php
+++ b/includes/class-eo-theme-compatability.php
@@ -451,5 +451,5 @@ class EO_Theme_Compat {
 	}
 
 }
-$compat = EO_Theme_Compat::get_instance();
-$compat->init();
+$eo_compat = EO_Theme_Compat::get_instance();
+$eo_compat->init();


### PR DESCRIPTION
wp-admin/includes/menu.php uses the `$compat` variable (in the global scope) to set up some menu globals. On my installation - which has EO network activated - the EO `$config` theme compat variable is overwriting WP's variable, which is causing fatal errors. I'm not 100% sure whether you'll be able to reproduce, but it seems a simple win to use a prefixed variable name.