### PR TITLE
Remove "year" from each day on full calendar responsive view

### DIFF
--- a/js/fullcalendar.js
+++ b/js/fullcalendar.js
@@ -10062,7 +10062,7 @@ var ListView = fcViews.list = View.extend({
 						date.format('dddd') +
 					'</span>' +
 					'<span class="fc-list-header-right">' +
-						date.format('MMM D, YYYY') +
+						date.format('MMM D') +
 					'</span>' +
 				'</td>';
 		}


### PR DESCRIPTION
Removed "year" from each day on the full calendar responsive view. Repeating the year was overkill, and added clutter to already small screens.