### PR TITLE
Add error and warning hooks to iCal parser

### DIFF
--- a/includes/class-eo-ical-parser.php
+++ b/includes/class-eo-ical-parser.php
@@ -513,6 +513,8 @@ class EO_ICAL_Parser{
 	 */
 	protected function report_error( $line, $type, $message ){
 
+		do_action( 'eventorganiser_ical_error' );
+		
 		if( is_array( $line ) ){
 			$this->errors[] = new WP_Error(
 				$type,
@@ -538,6 +540,8 @@ class EO_ICAL_Parser{
 	 */
 	protected function report_warning( $line, $type, $message ){
 	
+		do_action( 'eventorganiser_ical_warning' );
+		
 		if( is_array( $line ) ){
 			$this->warnings[] = new WP_Error(
 					$type,


### PR DESCRIPTION
Added hooks to report_error and report_warning functions. Intention is to allow an email to be sent to site administrator notifying of iCal syncing error or warning.