### PR TITLE
problems with translate.wordpress.org  in the recognition of text str…

### DIFF
--- a/event-organiser-settings.php
+++ b/event-organiser-settings.php
@@ -240,7 +240,7 @@ class EventOrganiser_Settings_Page extends EventOrganiser_Admin_Page{
 						'checked' => eventorganiser_get_option( 'excludefromsearch' ),
 				) );
 
-				add_settings_field( 'google_api_key',  __( 'Google API key:', 'eventorganiser' ), 'eventorganiser_text_field' , 'eventorganiser_' . $tab_id, $tab_id . '_google_maps',
+				add_settings_field( 'google_api_key',  __( "Google API key:", 'eventorganiser' ), 'eventorganiser_text_field' , 'eventorganiser_' . $tab_id, $tab_id . '_google_maps',
 					array(
 						'label_for' => 'google_api_key',
 						'name'      => 'eventorganiser_options[google_api_key]',


### PR DESCRIPTION
…ings

Hi! 
There is a large discrepancy in the translatable texts. Your pot-file says 480 strings and translate.wordpress.org recognizes only 424. I have the plugin that there are many differences. For example, between line 361 and 370th
help with times 'xxxx' and "xxxx"