### PR TITLE
[#404] Handle 767 byte index size limit in MySQL

### DIFF
--- a/includes/event-organiser-install.php
+++ b/includes/event-organiser-install.php
@@ -53,6 +53,12 @@ function eventorganiser_site_install() {
 		$charset_collate .= " COLLATE $wpdb->collate";
 	}
 
+	/*
+	 * Handling maximum index size of 767 bytes.
+	 * See wp_get_db_schema() function in wp-admin/includes/schema.php for more details.
+	 */
+	$max_index_length = 191;
+
 	//Events table
 	$sql_events_table = "CREATE TABLE {$wpdb->eo_events} (
 		event_id bigint(20) NOT NULL AUTO_INCREMENT,
@@ -75,7 +81,7 @@ function eventorganiser_site_install() {
 		meta_value longtext,
 		PRIMARY KEY  (meta_id),
 		KEY eo_venue_id (eo_venue_id),
-		KEY meta_key (meta_key)
+		KEY meta_key (meta_key($max_index_length))
 		) $charset_collate; ";
 
 	require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );


### PR DESCRIPTION
Fixes: #404 

Handles the issue exactly the same way as WordPress does ([here](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/schema.php#L47)):

    /*
     * Indexes have a maximum size of 767 bytes. Historically, we haven't need to be concerned about that.
     * As of 4.2, however, we moved to utf8mb4, which uses 4 bytes per character. This means that an index which
     * used to have room for floor(767/3) = 255 characters, now only has room for floor(767/4) = 191 characters.
     */
