### PR TITLE
Prevent errors if event-category tax is disabled

### DIFF
--- a/includes/event-organiser-event-functions.php
+++ b/includes/event-organiser-event-functions.php
@@ -1543,7 +1543,7 @@ function eo_get_event_meta_list( $event_id = 0 ) {
 		);
 	}
 
-	if ( get_the_terms( $event_id, 'event-category' ) ) {
+	if ( get_the_terms( $event_id, 'event-category' ) && !is_wp_error( get_the_terms( $event_id, 'event-category' ) ) ) {
 		$html .= sprintf(
 			'<li><strong>%s:</strong> %s</li>' . "\n",
 			__( 'Categories', 'eventorganiser' ),

--- a/templates/event-meta-event-single.php
+++ b/templates/event-meta-event-single.php
@@ -58,7 +58,7 @@
 			<li><strong><?php echo esc_html( $tax->labels->singular_name ) ?>:</strong> <a href="<?php eo_venue_link(); ?>"> <?php eo_venue_name(); ?></a></li>
 		<?php } ?>
 
-		<?php if ( get_the_terms( get_the_ID(), 'event-category' ) ) { ?>
+		<?php if ( get_the_terms( get_the_ID(), 'event-category' ) && ! is_wp_error( get_the_terms( get_the_ID(), 'event-category' ) ) ) { ?>
 			<li><strong><?php esc_html_e( 'Categories', 'eventorganiser' ); ?>:</strong> <?php echo get_the_term_list( get_the_ID(),'event-category', '', ', ', '' ); ?></li>
 		<?php } ?>
 


### PR DESCRIPTION
It's possible to disable event-tag and event-category (yeah!) but if event-category is disabled there will be problems with the event-meta information, as they try to query for both taxonomies and just for event-tag there is a check for WP Error. 

Please add the check for event-category as well - on this both places. 

I feel like my commit messages are not very clean. Maybe someone can help me by doing a cleaner merge request. The needed changes are simple. 