### PR TITLE
iCal: Use actual start date for DTSTART/DTEND

### DIFF
--- a/templates/ical.php
+++ b/templates/ical.php
@@ -32,8 +32,9 @@ if ( have_posts() ) :
 			continue;
 		}
 
-		$start         = eo_get_the_start( DATETIMEOBJ );
-		$end           = eo_get_the_end( DATETIMEOBJ );
+		$occurrences   = eo_get_the_occurrences_of();
+		$start         = reset( $occurrences )['start'];
+		$end           = reset( $occurrences )['end'];
 		$created_date  = get_post_time( 'Ymd\THis\Z',true );
 		$modified_date = get_post_modified_time( 'Ymd\THis\Z',true );
 		$schedule_data = eo_get_event_schedule();


### PR DESCRIPTION
Currently, DTSTART/DTEND are set to the start and end date of the post loop (`eo_get_the_start()`), but when grouping by posts, this might be the date of _any_ occurrence rather than the first.

The changed code retrieves the first occurrence using `eo_get_the_occurrences_of()` and then uses that. This fix has been successfully used in production for some days already, but I'm now wondering whether using the start/end dates of `eo_get_event_schedule()` might be more appropriate.