### PR TITLE
Use case-sensitive constants for PHP 7.3

### DIFF
--- a/event-organiser.php
+++ b/event-organiser.php
@@ -66,7 +66,7 @@ define( 'EVENT_ORGANISER_DIR', plugin_dir_path( __FILE__ ) );
 /**
  * For use in datetime formats. To return a datetime object rather than formatted string
  */
-define( 'DATETIMEOBJ', 'DATETIMEOBJ', true );
+define( 'DATETIMEOBJ', 'DATETIMEOBJ' );
 
 
 /**


### PR DESCRIPTION
In this [RFC for PHP 7.3](https://wiki.php.net/rfc/case_insensitive_constant_deprecation) the usage of case-insensitive constants and the third parameter of the `define()` function was deprecated.