### PR TITLE
AJAX: Fix issue if event categories are invalid

### DIFF
--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -221,7 +221,7 @@ function eventorganiser_public_fullcalendar() {
 			//Event categories
 			$terms = get_the_terms( $post->ID, 'event-category' );
 			$event['category']=array();
-			if( ! is_wp_error( $terms ) ) :
+			if ( $terms && ! is_wp_error( $terms ) ) :
 				foreach ($terms as $term):
 					$event['category'][]= $term->slug;
 					$event['className'][]='category-'.$term->slug;//deprecated. use eo-event-cat-{slug}

--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -221,7 +221,7 @@ function eventorganiser_public_fullcalendar() {
 			//Event categories
 			$terms = get_the_terms( $post->ID, 'event-category' );
 			$event['category']=array();
-			if($terms):
+			if( ! is_wp_error( $terms ) ) :
 				foreach ($terms as $term):
 					$event['category'][]= $term->slug;
 					$event['className'][]='category-'.$term->slug;//deprecated. use eo-event-cat-{slug}


### PR DESCRIPTION
Hi Stephen,

This PR fixes an issue when fetching events via AJAX if the event categories are invalid.

It basically mirrors what you have already done with event tags.  Probably just forgot to do the same for event categories.

Let me know if you have any questions!