### PR TITLE
change curly braces to square brackets for array access

### DIFF
--- a/includes/class-eo-ical-parser.php
+++ b/includes/class-eo-ical-parser.php
@@ -328,7 +328,7 @@ class EO_ICAL_Parser{
 
 			$j = $i+1;
 
-			while( isset( $lines[$j] ) && strlen( $lines[$j] ) > 0 && ( $lines[$j]{0} == ' ' || $lines[$j]{0} == "\t" )) {
+			while( isset( $lines[$j] ) && strlen( $lines[$j] ) > 0 && ( $lines[$j][0] == ' ' || $lines[$j][0] == "\t" )) {
 				$unfolded_lines[$i] .= rtrim( substr( $lines[$j], 1 ), "\n\r" );
 				$j++;
 			}


### PR DESCRIPTION
Fix array and string offset access syntax with curly braces is deprecated