### PR TITLE
Fix "Array and string offset access syntax with curly braces is deprecated" notice

### DIFF
--- a/includes/class-eo-ical-parser.php
+++ b/includes/class-eo-ical-parser.php
@@ -328,7 +328,7 @@ class EO_ICAL_Parser{
 
 			$j = $i+1;
 
-			while( isset( $lines[$j] ) && strlen( $lines[$j] ) > 0 && ( $lines[$j]{0} == ' ' || $lines[$j]{0} == "\t" )) {
+			while( isset( $lines[$j] ) && strlen( $lines[$j] ) > 0 && ( $lines[$j][0] == ' ' || $lines[$j][0] == "\t" )) {
 				$unfolded_lines[$i] .= rtrim( substr( $lines[$j], 1 ), "\n\r" );
 				$j++;
 			}


### PR DESCRIPTION
When `WP_DEBUG` is on, the `"Array and string offset access syntax with curly braces is deprecated"` notice gets displayed.

Reason is curly brace array access has been deprecated as of PHP 7.4.  See https://wiki.php.net/rfc/deprecate_curly_braces_array_access

PR fixes this.

