### PR TITLE
Replace eo_format_event_occurrence() for non-recurring event

### DIFF
--- a/includes/event-organiser-event-functions.php
+++ b/includes/event-organiser-event-functions.php
@@ -239,6 +239,10 @@ function eo_get_the_start( $format = 'd-m-Y', $post_id = 0, $occurrence_id = 0, 
 	$occurrence    = eo_get_the_occurrence( $post_id, $occurrence_id );
 
 	if ( ! $occurrence ) {
+		$occurrence = eo_get_event_schedule( $post_id );
+	}
+
+	if ( ! $occurrence ) {
 		return false;
 	}
 
@@ -417,6 +421,10 @@ function eo_get_the_end( $format = 'd-m-Y', $post_id = 0, $occurrence_id = 0, $d
 	$post_id       = (int) ( empty($post_id) ? get_the_ID() : $post_id);
 	$occurrence_id = (int) ( empty($occurrence_id) && isset($event->occurrence_id)  ? $event->occurrence_id : $occurrence_id);
 	$occurrence    = eo_get_the_occurrence( $post_id, $occurrence_id );
+
+	if ( ! $occurrence ) {
+		$occurrence = eo_get_event_schedule( $post_id );
+	}
 
 	if ( ! $occurrence ) {
 		return false;

--- a/templates/event-meta-event-single.php
+++ b/templates/event-meta-event-single.php
@@ -48,9 +48,11 @@
 
 	<ul class="eo-event-meta">
 
-		<?php if ( ! eo_recurs() ) { ?>
+		<?php if ( ! eo_recurs() ) {
+			$schedule = eo_get_event_schedule();
+		 ?>
 			<!-- Single event -->
-			<li><strong><?php esc_html_e( 'Date', 'eventorganiser' );?>:</strong> <?php echo eo_format_event_occurrence();?></li>
+			<li><strong><?php esc_html_e( 'Date', 'eventorganiser' );?>:</strong> <?php echo eo_format_datetime_range( $schedule['start'], $schedule['end'], eo_get_event_datetime_format() );?></li>
 		<?php } ?>
 
 		<?php if ( eo_get_venue() ) {


### PR DESCRIPTION
Hi Stephen,

We are seeing the following fatal error when on a non-recurring event page:

```
Uncaught Exception: Error in formating DateTime object. Expected DateTime, but instead given boolean in /wp-content/plugins/event-organiser/includes/event-organiser-utility-functions.php on line 31
```

The issue is the `Date` field in the template is using a function that appears to be used only for recurring events. I've replaced that call with `eo_get_event_schedule()` / `eo_format_datetime_range()` and that appears to have fixed the problem.

Not sure why this error is showing up now.

Let me know if you have any questions.