### PR TITLE
Update deprecated zIndex() function

### DIFF
--- a/js/admin-calendar.js
+++ b/js/admin-calendar.js
@@ -1330,7 +1330,7 @@ $.widget("ui.selectmenu", {
 
 		this.listWrap
 			.removeAttr( 'style' )
-			.zIndex( this.element.zIndex() + 2 )
+			.css( 'zIndex', this.element.css('zIndex') + 2 )
 			.position( $.extend( positionDefault, o.positionOptions ) );
 	}
 });


### PR DESCRIPTION
In WP 5.6, jQuery UI was updated to 1.12.1, [dropping support for the `zIndex()` function](https://jqueryui.com/upgrade-guide/1.12/#removed-zindex). See #499 for more information.

While the recommended approach is to replace this function using [stacking elements](https://api.jqueryui.com/theming/stacking-elements/), the affected code in this plugin can just as easily be replaced with the `.css('zIndex')` function since the original `zIndex()` function was just an abstraction method for the same. This is documented here: https://api.jqueryui.com/1.12/zIndex/

