### PR TITLE
Calendar widget: Cache contents using user ID as well

### DIFF
--- a/classes/class-eo-calendar-widget.php
+++ b/classes/class-eo-calendar-widget.php
@@ -198,10 +198,7 @@ class EO_Calendar_Widget extends WP_Widget {
 
 		$today = new DateTime( 'now', eo_get_blog_timezone() );
 
-		//Ensure a different cache key for those who can and cannot see private blogs
-		$args['_priv'] = current_user_can( 'read_private_events' ) ? '_priv' : false;
-
-		$key = $month->format( 'YM' ) . serialize( $args ) . get_locale() . $today->format( 'Y-m-d' );
+		$key = $month->format( 'YM' ) . serialize( $args ) . get_locale() . $today->format( 'Y-m-d' ) . get_current_user_id();
 		$calendar = get_transient( 'eo_widget_calendar' );
 		if ( ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) && $calendar && is_array( $calendar ) && isset( $calendar[$key] ) ) {
 			return $calendar[$key];


### PR DESCRIPTION
Hello,

Thank you for the work on developing this plugin!

I've stumbled upon a slight security issue in the calendar widget, which might leak a user's private events.

In order to reproduce:
1. Ensure you have the calendar widget somewhere on your site.
2. Create a new user (say `test`) without the `read_private_events` capacity.
3. Create a new private event and assign it to this user.
4. Log out and log in as this user.
5. Consult the calendar widget on your site and ensure you can see this user's private event. (Otherwise, clear the caches so that EO refreshes the widget contents.)
6. Log out.
7. Consult the calendar widget on your site: the new user's private event should still show up.

The expected behavior is that the private event shouldn't be displayed here: only `test` and users with the `read_private_events` should be able to see it.

It seems to me that this is because the caching mechanism for the calendar widget is a bit too lax: even when `read_private_events` isn't set for the current user, the calendar widget will still show their private events (which is expected), but they will then be cached for _any_ user who doesn't have the `read_private_events` capacity.

This tiny PR intends to fix this by using the current user's ID in the caching key instead of the `read_private_events` capacity. (Also, since the `_priv` key in the `$args` array then becomes useless, it is removed.)

From the tests I could run, this was enough to fix the issue.

Thanks!

Zosterops