### PR TITLE
Admin calendar: Avoid duplicate database query

### DIFF
--- a/includes/event-organiser-ajax.php
+++ b/includes/event-organiser-ajax.php
@@ -319,12 +319,9 @@ function eventorganiser_admin_calendar() {
 			wp_send_json( $calendar[$key] );
 		}
 
-		//Create query
+		//Create query and retrieve events
 		$query_array = array_merge($presets, $request);
 		$query = new WP_Query($query_array );
-
-		//Retrieve events
-		$query->get_posts();
 		$eventsarray = array();
 
 		//Blog timezone


### PR DESCRIPTION
Hello,

It seems that the `eventorganiser_admin_calendar()` function (which handles the `event-admin-cal` Ajax action) always performs the same database query twice.

In fact, the constructor for `WP_Query` [calls the `query()` method](https://github.com/WordPress/wordpress-develop/blob/6.0.1/src/wp-includes/class-wp-query.php#L3718), which itself already [calls the `get_posts()` method](https://github.com/WordPress/wordpress-develop/blob/6.0.1/src/wp-includes/class-wp-query.php#L3586). Therefore, calling `$query->get_posts()` after contructing the `$query` object is unnecessary, as all the posts are already available in the `$query` object, and it will needlessly repeat the previous database query.

This PR simply proposes to remove the call to `$query->get_posts()`.

Thanks!

Zosterops