### PR TITLE
`event.js`: Fix test for matching the start-date datepicker

### DIFF
--- a/js/event.js
+++ b/js/event.js
@@ -264,7 +264,7 @@ window.eventOrganiserSchedulePicker = {
                 instance = $(this).data("datepicker"),
                 date = $.datepicker.parseDate(instance.settings.dateFormat || $.datepicker._defaults.dateFormat, selectedDate, instance.settings);
                 dates.not(this).datepicker("option", option, date);
-                if (this.id == "from_date") {
+                if ('start' == $(this).data('eo-datepicker')) {
                 	//If updating start date, ensure recurrence end falls after this
                 	schedule_last.datepicker("option", "minDate", date);
                 }


### PR DESCRIPTION
Hello,

From what I could test from the current version of the plugin, when editing a recurring event, it seems that the recurrence end date (or “until” date) isn't updated when setting the event start date to a later date.

To reproduce:
1. Create a new event.
2. Leave everything as set by default in the editor: the start and end date for the event should be the current date (e.g., `2022-10-07` in `yyyy-mm-dd` format).
3. Pick a regular recurrence (daily or weekly, for instance), so that the “until” date shows in the form. This date should also be the same as the start and end dates above (i.e., `2022-10-07`, following the same example).
4. Set the start date to a later date (e.g., `2022-10-31`).
5. The “until” date hasn't changed (it is still `2022-10-07`).

However, one would expect the “until” date to be updated as well, since it now falls earlier than the event start date. This behavior is actually expected, as per the comment on line 268 of `js/event.js`:
https://github.com/stephenharris/Event-Organiser/blob/65c4e3b0f40a601bebf7d5fc2203da02bbb4d7e9/js/event.js#L265-L271

From what I could read from the code, it seems that this bug comes from the fact that the element ID of the start-date datepicker in the event editor has changed: it is not `from_date` (as written in the test on line 267 above), but `eo-start-date`.

A simple fix would be to write `eo-start-date` instead of `from_date` in the above test. However, since the role of each datepicker is now accessible using `$(element).data('eo-datepicker')`, it seems to me that matching this string should provide a more robust test for figuring out if we are currently handling events for a particular datepicker. The exact same test is already performed on line 263 of the same file, in the same function:
https://github.com/stephenharris/Event-Organiser/blob/65c4e3b0f40a601bebf7d5fc2203da02bbb4d7e9/js/event.js#L263

This is therefore the solution I'm proposing in this PR. From what I could test, this fixes the issue.

Another solution would be to use the jQuery selector `views.start_date`, retrieve the element matching the query, and check that it is the same as `this`. Something like
```js
if (this === $(views.start_date)[0]) {
	...
}
```
Of course, I'll gladly update my PR if you think this is a better solution!

I hope this will help! :)
In any case, thank you very much!

Zosterops