### PR TITLE
Update event-organiser-cpt.php

### DIFF
--- a/includes/event-organiser-cpt.php
+++ b/includes/event-organiser-cpt.php
@@ -119,6 +119,7 @@ function eventorganiser_create_event_taxonomies() {
 		'query_var'             => true,
 		'rewrite'               => $cat_rewrite,
 		'public'                => true,
+		'show_in_rest'			=> true,
 		'capabilities' => array(
 			'manage_terms' => 'manage_event_categories',
 			'edit_terms'   => 'manage_event_categories',


### PR DESCRIPTION
Somehow hte fix in 3.7.6 to show categories in Gutemberg disapperead at some point. It should be fixed again!

'show_in_rest'			=> true,